### PR TITLE
Feature, allow gifs, but block other documents like shady .scr virus files

### DIFF
--- a/watchdog_robot.py
+++ b/watchdog_robot.py
@@ -165,7 +165,7 @@ class WatchdogRobot(TgramRobot):
             ret.add('gif')
         if msg.voice:
             ret.add('voice')
-        if msg.document:
+        if msg.document and msg.document.mime_type != 'video/mp4':
             ret.add('attachment')
         if msg.audio:
             ret.add('audio')


### PR DESCRIPTION
Hi,

it would be nice to allow gifs, but still block other documents.

Maybe you can review it.

BR Merl